### PR TITLE
Sync all - loop through all repos since date

### DIFF
--- a/src/createJiraIssue.js
+++ b/src/createJiraIssue.js
@@ -82,7 +82,7 @@ export async function createChildIssues(
     return newJiraKey;
   } catch (error) {
     errorCollector.addError(
-      `Error creating child issues for parent ${parentJiraKey}`,
+      `CREATEJIRAISSUE: Error creating child issues for parent ${parentJiraKey}`,
       error
     );
   }
@@ -114,7 +114,7 @@ export async function createJiraIssue(githubIssue) {
     );
   } catch (error) {
     errorCollector.addError(
-      `Error creating Jira issue for GitHub issue #${githubIssue.number}`,
+      `CREATEJIRAISSUE: Error creating Jira issue for GitHub issue #${githubIssue.number}`,
       error
     );
   }

--- a/src/findJiraIssue.js
+++ b/src/findJiraIssue.js
@@ -73,7 +73,7 @@ const fetchJiraIssue = async (githubIssueLink) => {
     return foundIssue;
   } catch (error) {
     errorCollector.addError(
-      `Error finding Jira issue for GitHub issue ${githubIssueLink}`,
+      `FINDJIRAISSUE: Error finding Jira issue for GitHub issue ${githubIssueLink}`,
       error
     );
     return null;

--- a/src/handleUnprocessedJiraIssues.js
+++ b/src/handleUnprocessedJiraIssues.js
@@ -28,7 +28,8 @@ export async function handleUnprocessedJiraIssues(unprocessedJiraIssues) {
         await delay();
         const response = await executeGraphQLQuery(GET_ISSUE_DETAILS, {
           owner: process.env.GITHUB_OWNER,
-          repo: process.env.GITHUB_REPO,
+          // repo: process.env.GITHUB_REPO,
+          repo,
           issueNumber: githubNumber,
         });
 
@@ -49,12 +50,12 @@ export async function handleUnprocessedJiraIssues(unprocessedJiraIssues) {
         } else {
           // GH issue found & open, likely duplicate Jira
           console.log(
-            `  !! - Github issue #${githubNumber} found for unprocessed Jira ${jiraIssue.key}, check Jira for duplicate issue or sync GH/Jira issue status.`
+            `  !! - Github issue #${githubNumber} found for unprocessed Jira ${jiraIssue.key}, check Jira for duplicate issue or sync GH/Jira issue status (Github Iniatives may be skipped).`
           );
         }
       } catch (error) {
         errorCollector.addError(
-          `Could not find GitHub issue #${githubNumber} for Jira issue ${jiraIssue.key}`,
+          `HANDLEUNPROCESSEDJIRAISSUES: Could not find GitHub issue #${githubNumber} for Jira issue ${jiraIssue.key}`,
           error
         );
         console.log(

--- a/src/transitionJiraIssue.js
+++ b/src/transitionJiraIssue.js
@@ -31,7 +31,7 @@ export async function transitionJiraIssue(jiraIssueKey, targetState) {
     }
   } catch (error) {
     errorCollector.addError(
-      `Error transitioning Jira issue ${jiraIssueKey} to ${targetState}`,
+      `TRANSITION: Error transitioning Jira issue ${jiraIssueKey} to ${targetState}`,
       error
     );
   }

--- a/src/updateJiraIssue.js
+++ b/src/updateJiraIssue.js
@@ -23,7 +23,7 @@ async function findChildIssues(jiraIssueKey) {
     return response.data.issues;
   } catch (error) {
     errorCollector.addError(
-      `Error finding child issues for ${jiraIssueKey}`,
+      `UPDATEJIRA: Error finding child issues for ${jiraIssueKey}`,
       error
     );
     return [];
@@ -131,7 +131,7 @@ export async function updateChildIssues(parentJiraKey, githubIssue, isEpic) {
     }
   } catch (error) {
     errorCollector.addError(
-      `Error updating child issues for ${parentJiraKey} (GH #${githubIssue.number})`,
+      `UPDATEJIRA: Error updating child issues for ${parentJiraKey} (GH #${githubIssue.number})`,
       error
     );
   }
@@ -174,7 +174,7 @@ export async function updateJiraIssue(jiraIssue, githubIssue) {
     );
   } catch (error) {
     errorCollector.addError(
-      `Error updating Jira issue ${jiraIssue.key} (GH #${githubIssue.number})`,
+      `UPDATEJIRA: Error updating Jira issue ${jiraIssue.key} (GH #${githubIssue.number})`,
       error
     );
   }


### PR DESCRIPTION
This updates functionality from:
- Pulling all Github & Jira issues for a single repo, looping through every GH issue & syncing corresponding Jira issue, looping through remaining Jira issues & updating/closing as needed

to:
- Pull all open issues for all Github repos updated since `$since` date (both defined in helpers.js), loop through each and sync corresponding Jira issues.  Does not touch Jira issues without a linked open Github issue, since we're narrowing scope from all issues to just issues since a recent date.