### PR TITLE
chore: convert description field markdown for Jira using jira2md

### DIFF
--- a/src/createJiraIssue.js
+++ b/src/createJiraIssue.js
@@ -8,6 +8,7 @@ import {
 import { updateChildIssues } from './updateJiraIssue.js';
 import { transitionJiraIssue } from './transitionJiraIssue.js';
 import { errorCollector } from './index.js';
+import j2m from 'jira2md';
 
 export async function createChildIssues(
   parentJiraKey,
@@ -29,7 +30,7 @@ export async function createChildIssues(
           key: process.env.JIRA_PROJECT_KEY,
         },
         summary: subIssue.title,
-        description: `${subIssue?.body || ''}\n\n----\n\nGH Issue ${
+        description: `${subIssue?.body ? j2m.to_jira(subIssue.body) : ''}\n\n----\n\nGH Issue ${
           subIssue.number
         }\nUpstream URL: ${subIssue.url}\nReporter: ${
           subIssue?.author?.login || ''

--- a/src/createJiraIssue.js
+++ b/src/createJiraIssue.js
@@ -4,11 +4,11 @@ import {
   getJiraComponent,
   createNewJiraIssue,
   syncCommentsToJira,
+  convertMarkdownToJira,
 } from './helpers.js';
 import { updateChildIssues } from './updateJiraIssue.js';
 import { transitionJiraIssue } from './transitionJiraIssue.js';
 import { errorCollector } from './index.js';
-import j2m from 'jira2md';
 
 export async function createChildIssues(
   parentJiraKey,
@@ -30,7 +30,7 @@ export async function createChildIssues(
           key: process.env.JIRA_PROJECT_KEY,
         },
         summary: subIssue.title,
-        description: `${subIssue?.body ? j2m.to_jira(subIssue.body) : ''}\n\n----\n\nGH Issue ${
+        description: `${subIssue?.body ? convertMarkdownToJira(subIssue.body) : ''}\n\n----\n\nGH Issue ${
           subIssue.number
         }\nUpstream URL: ${subIssue.url}\nReporter: ${
           subIssue?.author?.login || ''

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -56,6 +56,16 @@ export async function editJiraIssue(jiraIssueKey, jiraIssueData) {
 export const delay = (ms = 1000) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+export const convertMarkdownToJira = (str) => {
+  // Custom image fix - extracts img src and wraps in ! 
+  let jiraMd = str.replaceAll(
+    /<img\b[^>]*src="([^"]+)"[^>]*\/>/gi,   // ← matches <img … src="…" … />
+    '!$1|width=30%!'                                  // ← wrap the captured URL in ! & set width to 30%
+  );
+  jiraMd = j2m.to_jira(jiraMd); // default replacements
+  return jiraMd;
+};
+  
 const platformTeamUsers = {
   nicolethoen: 'nthoen',
   dlabaj: 'dlabaj',
@@ -210,7 +220,7 @@ export const buildJiraIssueData = (githubIssue, isUpdateIssue = false) => {
     fields: {
       summary: title,
       description: `${
-        body ? j2m.to_jira(body) : ''
+        body ? convertMarkdownToJira(body) : ''
       }\n\n----\n\nGH Issue ${number}\nUpstream URL: ${url}\nReporter: ${
         author?.login || ''
       }\nAssignees: ${assigneeLogins.join(', ')}`,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -60,7 +60,7 @@ export const convertMarkdownToJira = (str) => {
   // Custom image fix - extracts img src and wraps in ! 
   let jiraMd = str.replaceAll(
     /<img\b[^>]*src="([^"]+)"[^>]*\/>/gi,   // ← matches <img … src="…" … />
-    '!$1|width=30%!'                                  // ← wrap the captured URL in ! & set width to 30%
+    '!$1|width=30%!'                        // ← wrap the captured URL in ! & set width to 30%
   );
   jiraMd = j2m.to_jira(jiraMd); // default replacements
   return jiraMd;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import axios from 'axios';
 import { errorCollector } from './index.js';
+import j2m from 'jira2md';
 
 // Initialize Octokit with GraphQL support
 export const octokit = new Octokit({
@@ -209,7 +210,7 @@ export const buildJiraIssueData = (githubIssue, isUpdateIssue = false) => {
     fields: {
       summary: title,
       description: `${
-        body || ''
+        body ? j2m.to_jira(body) : ''
       }\n\n----\n\nGH Issue ${number}\nUpstream URL: ${url}\nReporter: ${
         author?.login || ''
       }\nAssignees: ${assigneeLogins.join(', ')}`,


### PR DESCRIPTION
Closes #5

This PR:
- uses the jira2md package to convert description field markdown before posting to Jira
- adds custom fix for images, which extracts the `src` value from the `<img>` tag, formats it for Jira by wrapping the url in exclamation marks, and sets the width to 30% to avoid giant images.